### PR TITLE
refactor(web-react): add encoder to support non-ASCII characters csv download

### DIFF
--- a/datahub-web-react/src/app/search/utils/csvUtils.ts
+++ b/datahub-web-react/src/app/search/utils/csvUtils.ts
@@ -1,5 +1,5 @@
 export function downloadFile(data: string, title: string) {
-    const blobx = new Blob([data], { type: 'text/plain' }); // ! Blob
+    const blobx = new Blob([data], { type: 'text/plain;chartset=utf-8' }); // ! Blob
     const elemx = window.document.createElement('a');
     elemx.href = window.URL.createObjectURL(blobx); // ! createObjectURL
     elemx.download = title;


### PR DESCRIPTION
The change is intended to allow utf-8 encoder while download csv file, to support non-ASCII characters (ex. Thai) 

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
